### PR TITLE
Support for Soma blinds

### DIFF
--- a/src/main/resources/gatt/characteristic/org.bluetooth.characteristic.somablind_motor.xml
+++ b/src/main/resources/gatt/characteristic/org.bluetooth.characteristic.somablind_motor.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?><!--Copyright 2011 Bluetooth SIG, Inc. All rights reserved.-->
+<Characteristic xsi:noNamespaceSchemaLocation="http://schemas.bluetooth.org/Documents/characteristic.xsd"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="MotorControl"
+                type="org.bluetooth.characteristic.somablind" uuid="1530" last-modified="2011-12-05"
+                approved="No">
+    <InformativeText>
+        <Abstract>
+			Motor Control 
+        </Abstract>
+    </InformativeText>
+    <Value>
+        <Field name="Target">
+            <Requirement>Mandatory</Requirement>
+            <!-- <Format>utf8s</Format> -->
+            <Format>uint8</Format>
+        </Field>
+    </Value>
+</Characteristic>

--- a/src/main/resources/gatt/characteristic/org.bluetooth.characteristic.somablind_position.xml
+++ b/src/main/resources/gatt/characteristic/org.bluetooth.characteristic.somablind_position.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?><!--Copyright 2011 Bluetooth SIG, Inc. All rights reserved.-->
+<Characteristic xsi:noNamespaceSchemaLocation="http://schemas.bluetooth.org/Documents/characteristic.xsd"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Position"
+                type="org.bluetooth.characteristic.somablind" uuid="1525" last-modified="2011-12-05"
+                approved="No">
+    <InformativeText>
+        <Abstract>
+			Position of blinds
+        </Abstract>
+    </InformativeText>
+    <Value>
+        <Field name="Position">
+            <Requirement>Mandatory</Requirement>
+            <Format>uint8</Format>
+        </Field>
+    </Value>
+</Characteristic>

--- a/src/main/resources/gatt/characteristic/org.bluetooth.characteristic.somablind_target.xml
+++ b/src/main/resources/gatt/characteristic/org.bluetooth.characteristic.somablind_target.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?><!--Copyright 2011 Bluetooth SIG, Inc. All rights reserved.-->
+<Characteristic xsi:noNamespaceSchemaLocation="http://schemas.bluetooth.org/Documents/characteristic.xsd"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Target"
+                type="org.bluetooth.characteristic.somablind" uuid="1526" last-modified="2011-12-05"
+                approved="No">
+    <InformativeText>
+        <Abstract>
+			Target of blinds
+        </Abstract>
+    </InformativeText>
+    <Value>
+        <Field name="Target">
+            <Requirement>Mandatory</Requirement>
+            <!-- <Format>utf8s</Format> -->
+            <Format>uint8</Format>
+        </Field>
+    </Value>
+</Characteristic>

--- a/src/main/resources/gatt/service/org.bluetooth.service.somablind.xml
+++ b/src/main/resources/gatt/service/org.bluetooth.service.somablind.xml
@@ -1,0 +1,45 @@
+<Service xsi:noNamespaceSchemaLocation="http://schemas.bluetooth.org/Documents/service.xsd"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Soma Blinds"
+         type="org.bluetooth.service.blind_service" uuid="1861" last-modified="2018-09-06">
+<InformativeText>
+    <Abstract>
+        Soma Blinds control
+    </Abstract>
+    <Summary>
+        Controller for Soma Blinds
+    </Summary>
+</InformativeText>
+<Dependencies>
+    <Dependency>This service has no dependencies on other GATT-based services.</Dependency>
+</Dependencies>
+<GATTRequirements>
+    <Requirement subProcedure="Write Characteristic Value">Mandatory</Requirement>
+    <Requirement subProcedure="Notification">Mandatory</Requirement>
+    <Requirement subProcedure="Read Characteristic Descriptors">Mandatory</Requirement>
+    <Requirement subProcedure="Write Characteristic Descriptors">Mandatory</Requirement>
+</GATTRequirements>
+<Transports>
+    <Classic>false</Classic>
+    <LowEnergy>true</LowEnergy>
+</Transports>
+<ErrorCodes>
+</ErrorCodes>
+<Characteristics>
+    <Characteristic name="Soma Blinds"
+                    type="org.bluetooth.characteristic.somablind">
+        <InformativeText>Blind control</InformativeText>
+        <Requirement>Mandatory</Requirement>
+        <Properties>
+            <Read>Excluded</Read>
+            <Write>Excluded</Write>
+            <WriteWithoutResponse>Excluded</WriteWithoutResponse>
+            <SignedWrite>Excluded</SignedWrite>
+            <ReliableWrite>Excluded</ReliableWrite>
+            <Notify>Excluded</Notify>
+            <Indicate>Mandatory</Indicate>
+            <WritableAuxiliaries>Excluded</WritableAuxiliaries>
+            <Broadcast>Excluded</Broadcast>
+        </Properties>
+    </Characteristic>
+</Characteristics>
+</Service>


### PR DESCRIPTION
Support added for Soma blinds with gatt files.

Examples:

```
Number FrontRoomBlindsRight_Battery             "Front room blinds - Right - Battery [%.0f %]"                            {channel="bluetooth:ble:C1037491056C:180F-2A19-level"}
Switch FrontRoomBlindsRight_Connected           "Front room blinds - Right - Connected"                          {channel="bluetooth:ble:C1037491056C:connected"}
Switch FrontRoomBlindsRight_Online              "Front room blinds - Right - Online"                             {channel="bluetooth:ble:C1037491056C:online"}
Number FrontRoomBlindsRight_Position            "Front room blinds - Right - Position [%.0f %]"                           {channel="bluetooth:ble:C1037491056C:1861-1525-position"}
Number FrontRoomBlindsRight_Target              "Front room blinds - Right - Target"                             {channel="bluetooth:ble:C1037491056C:1861-1526-target"}
Number FrontRoomBlindsRight_MotorControl        "Front room blinds - Right - Motor"                              {channel="bluetooth:ble:C1037491056C:1861-1530-target"}
Number FrontRoomBlindsRight_RSSI        "Front room blinds - Right - RSSI"                              {channel="bluetooth:ble:C1037491056C:rssi"}

```