### PR TITLE
Add support for r00li devices

### DIFF
--- a/src/main/resources/gatt/characteristic/com.r00li.bluetooth.characteristic.bleio_input.xml
+++ b/src/main/resources/gatt/characteristic/com.r00li.bluetooth.characteristic.bleio_input.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?><!-- Copyright 2011 Bluetooth SIG, Inc. All rights reserved. -->
+<Characteristic xsi:noNamespaceSchemaLocation="http://schemas.bluetooth.org/Documents/characteristic.xsd"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                type="com.r00li.bluetooth.characteristic.bleio_input" name="BLE_IO_Input"
+                uuid="B3F10001-56E7-48AD-7D48-88BBB2198D75">
+    <InformativeText></InformativeText>
+    <Value>
+        <Field name="Input state">
+            <Requirement>Mandatory</Requirement>
+            <Format>8bit</Format>
+            <BitField>
+                <Bit index="0" size="1" name="Input 1">
+                    <Format>boolean</Format>
+                </Bit>
+                <Bit index="1" size="1" name="Input 2">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="2" size="1" name="Input 3">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="3" size="1" name="Input 4">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="4" size="1" name="Input 5">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="5" size="1" name="Input 6">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="6" size="1" name="Input 7">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="7" size="1" name="Input 8">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+            </BitField>
+        </Field>
+    </Value>
+</Characteristic>
+

--- a/src/main/resources/gatt/characteristic/com.r00li.bluetooth.characteristic.bleio_input.xml
+++ b/src/main/resources/gatt/characteristic/com.r00li.bluetooth.characteristic.bleio_input.xml
@@ -10,7 +10,10 @@
             <Format>8bit</Format>
             <BitField>
                 <Bit index="0" size="1" name="Input 1">
-                    <Format>boolean</Format>
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
                 </Bit>
                 <Bit index="1" size="1" name="Input 2">
                     <Enumerations>

--- a/src/main/resources/gatt/characteristic/com.r00li.bluetooth.characteristic.bleio_output.xml
+++ b/src/main/resources/gatt/characteristic/com.r00li.bluetooth.characteristic.bleio_output.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?><!-- Copyright 2011 Bluetooth SIG, Inc. All rights reserved. -->
+<Characteristic xsi:noNamespaceSchemaLocation="http://schemas.bluetooth.org/Documents/characteristic.xsd"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                type="com.r00li.bluetooth.characteristic.bleio_output" name="BLE_IO_Output"
+                uuid="B3F10002-56E7-48AD-7D48-88BBB2198D75">
+    <InformativeText></InformativeText>
+    <Value>
+        <Field name="Output state">
+            <Requirement>Mandatory</Requirement>
+            <Format>8bit</Format>
+            <BitField>
+                <Bit index="0" size="1" name="Output 1">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="1" size="1" name="Output 2">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="2" size="1" name="Output 3">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="3" size="1" name="Output 4">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="4" size="1" name="Output 5">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="5" size="1" name="Output 6">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="6" size="1" name="Output 7">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+                <Bit index="7" size="1" name="Output 8">
+                    <Enumerations>
+                        <Enumeration key="0" value="false"/>
+                        <Enumeration key="1" value="true"/>
+                    </Enumerations>
+                </Bit>
+            </BitField>
+        </Field>
+    </Value>
+</Characteristic>

--- a/src/main/resources/gatt/characteristic/com.r00li.bluetooth.characteristic.rswitchv2.xml
+++ b/src/main/resources/gatt/characteristic/com.r00li.bluetooth.characteristic.rswitchv2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?><!-- Copyright 2011 Bluetooth SIG, Inc. All rights reserved. -->
+<Characteristic xsi:noNamespaceSchemaLocation="http://schemas.bluetooth.org/Documents/characteristic.xsd"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                type="com.r00li.bluetooth.characteristic.rswitchv2" name="RSwitch_V2"
+                uuid="1BC50001-0200-4B87-E611-A639601728BB">
+    <InformativeText></InformativeText>
+    <Value>
+        <Field name="Switch state">
+            <Requirement>Mandatory</Requirement>
+            <Format>uint8</Format>
+            <Unit>org.bluetooth.unit.percentage</Unit>
+            <Minimum>0</Minimum>
+            <Maximum>100</Maximum>
+            <Enumerations>
+                <Reserved start="101" end="255"/>
+            </Enumerations>
+        </Field>
+    </Value>
+</Characteristic>
+

--- a/src/main/resources/gatt/characteristic/com.r00li.bluetooth.characteristic.rtemp_humidity.xml
+++ b/src/main/resources/gatt/characteristic/com.r00li.bluetooth.characteristic.rtemp_humidity.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?><!-- Copyright 2011 Bluetooth SIG, Inc. All rights reserved. -->
+<Characteristic xsi:noNamespaceSchemaLocation="http://schemas.bluetooth.org/Documents/characteristic.xsd"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                type="com.r00li.bluetooth.characteristic.rtemp_humidity" name="RTemp_Humidity"
+                uuid="1BC50002-0200-3180-E511-9DA1608C7B7B">
+    <InformativeText></InformativeText>
+    <Value>
+        <Field name="Humidity Value">
+            <Requirement>Mandatory</Requirement>
+            <Format>uint8</Format>
+            <Unit>org.bluetooth.unit.percentage</Unit>
+            <DecimalExponent>0</DecimalExponent>
+        </Field>
+    </Value>
+</Characteristic>
+

--- a/src/main/resources/gatt/characteristic/com.r00li.bluetooth.characteristic.rtemp_temperature.xml
+++ b/src/main/resources/gatt/characteristic/com.r00li.bluetooth.characteristic.rtemp_temperature.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?><!-- Copyright 2011 Bluetooth SIG, Inc. All rights reserved. -->
+<Characteristic xsi:noNamespaceSchemaLocation="http://schemas.bluetooth.org/Documents/characteristic.xsd"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                type="com.r00li.bluetooth.characteristic.rtemp_temperature" name="RTemp_Temperature"
+                uuid="1BC50001-0200-3180-E511-9DA1608C7B7B">
+    <InformativeText></InformativeText>
+    <Value>
+        <Field name="Temperature Value">
+            <Requirement>Mandatory</Requirement>
+            <Format>uint32</Format>
+        </Field>
+    </Value>
+</Characteristic>
+

--- a/src/main/resources/gatt/service/com.r00li.bluetooth.service.bleio.xml
+++ b/src/main/resources/gatt/service/com.r00li.bluetooth.service.bleio.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright 2011 Bluetooth SIG, Inc. All rights reserved. -->
+<Service xsi:noNamespaceSchemaLocation="http://schemas.bluetooth.org/Documents/service.xsd"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="com.r00li.bluetooth.service.bleio" uuid="B3F10000-56E7-48AD-7D48-88BBB2198D75"
+         name="BLE IO">
+    <InformativeText>
+        <Abstract>
+            IO Service
+        </Abstract>
+        <Summary>
+            IO Service
+        </Summary>
+    </InformativeText>
+    <Dependencies>
+        <Dependency>This service is not dependent upon any other services.</Dependency>
+    </Dependencies>
+    <GATTRequirements>
+        <Requirement subProcedure="Write Characteristic Value">Mandatory</Requirement>
+        <Requirement subProcedure="Notifications">Mandatory</Requirement>
+        <Requirement subProcedure="Read Characteristic Descriptors">Mandatory</Requirement>
+    </GATTRequirements>
+    <Transports>
+        <Classic>false</Classic>
+        <LowEnergy>true</LowEnergy>
+    </Transports>
+    <ErrorCodes>
+    </ErrorCodes>
+    <Characteristics>
+        <Characteristic name="BLE_IO_Input" type="com.r00li.bluetooth.characteristic.bleio_input">
+            <InformativeText>
+                Input state
+            </InformativeText>
+            <Requirement>Mandatory</Requirement>
+            <Properties>
+                <Read>Mandatory</Read>
+                <Write>Excluded</Write>
+                <WriteWithoutResponse>Excluded</WriteWithoutResponse>
+                <SignedWrite>Excluded</SignedWrite>
+                <ReliableWrite>Excluded</ReliableWrite>
+                <Notify>Mandatory</Notify>
+                <Indicate>Excluded</Indicate>
+                <WritableAuxiliaries>Excluded</WritableAuxiliaries>
+                <Broadcast>Excluded</Broadcast>
+            </Properties>
+        </Characteristic>
+        <Characteristic name="BLE_IO_Output" type="com.r00li.bluetooth.characteristic.bleio_output">
+            <InformativeText>
+                Output state
+            </InformativeText>
+            <Requirement>Mandatory</Requirement>
+            <Properties>
+                <Read>Mandatory</Read>
+                <Write>Mandatory</Write>
+                <WriteWithoutResponse>Excluded</WriteWithoutResponse>
+                <SignedWrite>Excluded</SignedWrite>
+                <ReliableWrite>Excluded</ReliableWrite>
+                <Notify>Excluded</Notify>
+                <Indicate>Excluded</Indicate>
+                <WritableAuxiliaries>Excluded</WritableAuxiliaries>
+                <Broadcast>Excluded</Broadcast>
+            </Properties>
+        </Characteristic>
+    </Characteristics>
+</Service>
+

--- a/src/main/resources/gatt/service/com.r00li.bluetooth.service.rswitchv2.xml
+++ b/src/main/resources/gatt/service/com.r00li.bluetooth.service.rswitchv2.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright 2011 Bluetooth SIG, Inc. All rights reserved. -->
+<Service xsi:noNamespaceSchemaLocation="http://schemas.bluetooth.org/Documents/service.xsd"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="com.r00li.bluetooth.service.rswitchv2" uuid="1BC50000-0200-4B87-E611-A639601728BB"
+         name="RSwitch V2">
+    <InformativeText>
+        <Abstract>
+            Dimmer service
+        </Abstract>
+        <Summary>
+            Dimmer service
+        </Summary>
+    </InformativeText>
+    <Dependencies>
+        <Dependency>This service is not dependent upon any other services.</Dependency>
+    </Dependencies>
+    <GATTRequirements>
+        <Requirement subProcedure="Write Characteristic Value">Mandatory</Requirement>
+        <Requirement subProcedure="Read Characteristic Descriptors">Mandatory</Requirement>
+    </GATTRequirements>
+    <Transports>
+        <Classic>false</Classic>
+        <LowEnergy>true</LowEnergy>
+    </Transports>
+    <ErrorCodes>
+    </ErrorCodes>
+    <Characteristics>
+        <Characteristic name="RSwitch_V2" type="com.r00li.bluetooth.characteristic.rswitchv2">
+            <InformativeText>
+                Dimmer state
+            </InformativeText>
+            <Requirement>Mandatory</Requirement>
+            <Properties>
+                <Read>Mandatory</Read>
+                <Write>Mandatory</Write>
+                <WriteWithoutResponse>Excluded</WriteWithoutResponse>
+                <SignedWrite>Excluded</SignedWrite>
+                <ReliableWrite>Excluded</ReliableWrite>
+                <Notify>Excluded</Notify>
+                <Indicate>Excluded</Indicate>
+                <WritableAuxiliaries>Excluded</WritableAuxiliaries>
+                <Broadcast>Excluded</Broadcast>
+            </Properties>
+        </Characteristic>
+    </Characteristics>
+</Service>
+

--- a/src/main/resources/gatt/service/com.r00li.bluetooth.service.rtemp.xml
+++ b/src/main/resources/gatt/service/com.r00li.bluetooth.service.rtemp.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright 2011 Bluetooth SIG, Inc. All rights reserved. -->
+<Service xsi:noNamespaceSchemaLocation="http://schemas.bluetooth.org/Documents/service.xsd"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" type="com.r00li.bluetooth.service.rtemp" uuid="1BC50000-0200-3180-E511-9DA1608C7B7B"
+         name="RTemp">
+    <InformativeText>
+        <Abstract>
+            Temperature sensor service
+        </Abstract>
+        <Summary>
+            Temperature sensor service
+        </Summary>
+    </InformativeText>
+    <Dependencies>
+        <Dependency>This service is not dependent upon any other services.</Dependency>
+    </Dependencies>
+    <GATTRequirements>
+        <Requirement subProcedure="Notifications">Mandatory</Requirement>
+        <Requirement subProcedure="Read Characteristic Value">Mandatory</Requirement>
+    </GATTRequirements>
+    <Transports>
+        <Classic>false</Classic>
+        <LowEnergy>true</LowEnergy>
+    </Transports>
+    <ErrorCodes>
+    </ErrorCodes>
+    <Characteristics>
+        <Characteristic name="RTemp_Temperature" type="com.r00li.bluetooth.characteristic.rtemp_temperature">
+            <InformativeText>
+                Temperature value
+            </InformativeText>
+            <Requirement>Mandatory</Requirement>
+            <Properties>
+                <Read>Mandatory</Read>
+                <Write>Excluded</Write>
+                <WriteWithoutResponse>Excluded</WriteWithoutResponse>
+                <SignedWrite>Excluded</SignedWrite>
+                <ReliableWrite>Excluded</ReliableWrite>
+                <Notify>Mandatory</Notify>
+                <Indicate>Excluded</Indicate>
+                <WritableAuxiliaries>Excluded</WritableAuxiliaries>
+                <Broadcast>Excluded</Broadcast>
+            </Properties>
+        </Characteristic>
+        <Characteristic name="RTemp_Humidity" type="com.r00li.bluetooth.characteristic.rtemp_humidity">
+            <InformativeText>
+                Humidity value
+            </InformativeText>
+            <Requirement>Mandatory</Requirement>
+            <Properties>
+                <Read>Mandatory</Read>
+                <Write>Excluded</Write>
+                <WriteWithoutResponse>Excluded</WriteWithoutResponse>
+                <SignedWrite>Excluded</SignedWrite>
+                <ReliableWrite>Excluded</ReliableWrite>
+                <Notify>Mandatory</Notify>
+                <Indicate>Excluded</Indicate>
+                <WritableAuxiliaries>Excluded</WritableAuxiliaries>
+                <Broadcast>Excluded</Broadcast>
+            </Properties>
+        </Characteristic>
+    </Characteristics>
+</Service>
+


### PR DESCRIPTION
Added XMLs for my own custom devices that use 128bit UUIDs as discussed here:
https://github.com/sputnikdev/eclipse-smarthome-bluetooth-binding/issues/67