### PR TITLE
support newer xstream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.7</version>
+            <version>1.4.19</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/org/sputnikdev/bluetooth/gattparser/spec/BluetoothGattSpecificationReader.java
+++ b/src/main/java/org/sputnikdev/bluetooth/gattparser/spec/BluetoothGattSpecificationReader.java
@@ -29,12 +29,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -44,7 +42,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Scanner;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -397,6 +394,8 @@ public class BluetoothGattSpecificationReader {
     private <T> T getSpec(URL file) {
         try {
             XStream xstream = new XStream(new DomDriver());
+            xstream.allowTypesByWildcard(
+                    new String[]{getClass().getPackage().getName() + ".*"});
             xstream.autodetectAnnotations(true);
             xstream.processAnnotations(Bit.class);
             xstream.processAnnotations(BitField.class);


### PR DESCRIPTION
The library `bluetooth-gatt-parser` is dependant on an older version of xstream.
Newer versions of xstream require a security configuration for it to work.

The open source project [OpenHAB](https://www.openhab.org/) uses `bluetooth-gatt-parser` in its [Generic Bluetooth Device Binding](https://www.openhab.org/addons/bindings/bluetooth.generic/) which needs to use a newer xtream as other parts of OpenHAB use it too.